### PR TITLE
feat(report): add income/both flags for category report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-A simple expense tracker in Rust.
+# Expense Tracker (Rust)
 
-- `cli/` : CLI app using SQLite
-- `ledger_module/` : Core module (DB/domain logic)
+A simple expense & income tracker written in Rust.  
+Uses SQLite for storage, with a modular design:
 
-## CLI quick start
+- `cli/` : CLI app (user interface)
+- `ledger_module/` : Core module (DB access & domain logic)
+
+---
+
+## Features
+- Add expenses and income
+- List all entries
+- Delete by ID
+- Monthly summary (income / expense / balance)
+- Category totals (per month, for expense / income / both)
+
+---
+
+## CLI Quick Start
+
+### Add entry
 ```bash
+# Expense
 cargo run -p cli -- add expense 1200 food Lunch
-cargo run -p cli -- list
-```
+
+# Income
+cargo run -p cli -- add income 50000 salary "August salary"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,11 @@
-use ledger_module::{open_db, init_db, add_entry, list_entries, Kind};
+use ledger_module::{
+    Kind, add_entry, category_totals_by_kind, init_db, list_entries, month_summary, open_db,
+};
+
+fn current_ym() -> String {
+    let now = chrono::Local::now();
+    now.format("%Y-%m").to_string()
+}
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -7,14 +14,17 @@ fn main() {
     init_db(&conn).expect("Failed to initialize database");
 
     if args.len() < 2 {
-        eprintln!("Usage: {} <command> [add|list...]", args[0]);
+        eprintln!("Usage: {} <command> [add|list|delete|report ...]", args[0]);
         return;
     }
 
     match args[1].as_str() {
         "add" => {
             if args.len() < 5 {
-                eprintln!("Usage: {} add <kind> <amount> <category> [note]", args[0]);
+                eprintln!(
+                    "Usage: {} add <expense|income> <amount> <category> [note...]",
+                    args[0]
+                );
                 return;
             }
             let kind = match args[2].as_str() {
@@ -38,20 +48,32 @@ fn main() {
             } else {
                 None
             };
-
             add_entry(&conn, kind, amount, category, note.as_deref()).expect("Failed to add entry");
             println!("Entry added successfully.");
-        },
-        "list" => {
-            match list_entries(&conn) {
-                Ok(entries) => {
-                    for entry in entries {
-                        println!("{}: {} {} {} {} [{}]", entry.created_at, if entry.kind == Kind::Expense { "Expense" } else { "Income" }, entry.amount, entry.category, entry.note.as_deref().unwrap_or(""), entry.id);
-                    }
-                },
-                Err(e) => eprintln!("Failed to list entries: {}", e),
+        }
+
+        "list" => match list_entries(&conn) {
+            Ok(entries) => {
+                for entry in entries {
+                    let k = if entry.kind == Kind::Expense {
+                        "Expense"
+                    } else {
+                        "Income"
+                    };
+                    println!(
+                        "{}: {} {} {} {} [{}]",
+                        entry.created_at,
+                        k,
+                        entry.amount,
+                        entry.category,
+                        entry.note.as_deref().unwrap_or(""),
+                        entry.id
+                    );
+                }
             }
+            Err(e) => eprintln!("Failed to list entries: {}", e),
         },
+
         "delete" => {
             if args.len() < 3 {
                 eprintln!("Usage: {} delete <id>", args[0]);
@@ -69,9 +91,98 @@ fn main() {
                 Ok(_) => println!("No entry found with ID: {}", id),
                 Err(e) => eprintln!("Failed to delete entry: {}", e),
             }
-        },
+        }
+
+        "report" => {
+            if args.len() < 3 {
+                eprintln!(
+                    "Usage: {} report <month|category> [YYYY-MM] [--income|--expense|--both]",
+                    args[0]
+                );
+                return;
+            }
+            let ym = if args.len() >= 4 && !args[3].starts_with("--") {
+                args[3].clone()
+            } else {
+                current_ym()
+            };
+
+            match args[2].as_str() {
+                "month" => match month_summary(&conn, &ym) {
+                    Ok(s) => {
+                        println!("== Summary {} ==", s.month);
+                        println!("Income : {}", s.income);
+                        println!("Expense: {}", s.expense);
+                        println!("Balance: {}", s.balance);
+                    }
+                    Err(e) => eprintln!("Failed to get month summary: {}", e),
+                },
+
+                "category" => {
+                    let flag = args
+                        .iter()
+                        .find(|a| a.starts_with("--"))
+                        .map(|s| s.as_str());
+                    match flag {
+                        Some("--both") => {
+                            let exp = category_totals_by_kind(&conn, &ym, Kind::Expense)
+                                .unwrap_or_default();
+                            let inc = category_totals_by_kind(&conn, &ym, Kind::Income)
+                                .unwrap_or_default();
+
+                            println!("== Category Totals (Expense) {} ==", ym);
+                            if exp.is_empty() {
+                                println!("(no data)");
+                            }
+                            for r in exp {
+                                println!("{:12} {}", r.category, r.total);
+                            }
+
+                            println!();
+                            println!("== Category Totals (Income)  {} ==", ym);
+                            if inc.is_empty() {
+                                println!("(no data)");
+                            }
+                            for r in inc {
+                                println!("{:12} {}", r.category, r.total);
+                            }
+                        }
+                        Some("--income") => {
+                            let rows = category_totals_by_kind(&conn, &ym, Kind::Income)
+                                .unwrap_or_default();
+                            println!("== Category Totals (Income) {} ==", ym);
+                            if rows.is_empty() {
+                                println!("(no data)");
+                            }
+                            for r in rows {
+                                println!("{:12} {}", r.category, r.total);
+                            }
+                        }
+                        _ => {
+                            let rows = category_totals_by_kind(&conn, &ym, Kind::Expense)
+                                .unwrap_or_default();
+                            println!("== Category Totals (Expense) {} ==", ym);
+                            if rows.is_empty() {
+                                println!("(no data)");
+                            }
+                            for r in rows {
+                                println!("{:12} {}", r.category, r.total);
+                            }
+                        }
+                    }
+                }
+
+                _ => {
+                    eprintln!(
+                        "Unknown report type: {}. Use 'month' or 'category'.",
+                        args[2]
+                    );
+                }
+            }
+        }
+
         _ => {
             eprintln!("Unknown command: {}. Use 'add' or 'list'.", args[1]);
-        } 
+        }
     }
 }

--- a/ledger_module/src/lib.rs
+++ b/ledger_module/src/lib.rs
@@ -1,10 +1,20 @@
 use rusqlite::{Connection, params};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub enum Kind { Expense, Income }
+pub enum Kind {
+    Expense,
+    Income,
+}
 impl Kind {
-    pub fn to_i64(self) -> i64 { match self { Kind::Expense => 0, Kind::Income => 1 } }
-    pub fn from_i64(v: i64) -> Self { if v == 0 { Kind::Expense } else { Kind::Income } }
+    pub fn to_i64(self) -> i64 {
+        match self {
+            Kind::Expense => 0,
+            Kind::Income => 1,
+        }
+    }
+    pub fn from_i64(v: i64) -> Self {
+        if v == 0 { Kind::Expense } else { Kind::Income }
+    }
 }
 
 #[derive(Debug)]
@@ -56,7 +66,7 @@ pub fn list_entries(conn: &Connection) -> rusqlite::Result<Vec<Entry>> {
         SELECT id, kind, amount, category, note, created_at
         FROM entries
         ORDER BY datetime(created_at) DESC
-        "#
+        "#,
     )?;
     let rows = stmt.query_map([], |row| {
         Ok(Entry {
@@ -70,10 +80,79 @@ pub fn list_entries(conn: &Connection) -> rusqlite::Result<Vec<Entry>> {
     })?;
 
     let mut v = Vec::new();
-    for r in rows { v.push(r?); }
+    for r in rows {
+        v.push(r?);
+    }
     Ok(v)
 }
 
 pub fn delete_entry(conn: &Connection, id: i64) -> rusqlite::Result<usize> {
     conn.execute("DELETE FROM entries WHERE id = ?1", params![id])
+}
+
+pub struct MonthSummary {
+    pub month: String,
+    pub expense: i64,
+    pub income: i64,
+    pub balance: i64,
+}
+
+pub fn month_summary(conn: &Connection, ym: &str) -> rusqlite::Result<MonthSummary> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT
+            SUM(CASE WHEN kind = 1 THEN amount ELSE 0 END) AS income,
+            SUM(CASE WHEN kind = 0 THEN amount ELSE 0 END) AS expense
+        FROM entries
+        WHERE substr(created_at, 1, 7) = ?1
+        "#,
+    )?;
+
+    let (income_opt, expense_opt): (Option<i64>, Option<i64>) =
+        stmt.query_row(params![ym], |row| Ok((row.get(0)?, row.get(1)?)))?;
+
+    let income = income_opt.unwrap_or(0);
+    let expense = expense_opt.unwrap_or(0);
+
+    Ok(MonthSummary {
+        month: ym.to_string(),
+        income,
+        expense,
+        balance: income - expense,
+    })
+}
+
+#[derive(Debug)]
+pub struct CategoryTotal {
+    pub category: String,
+    pub total: i64,
+}
+
+pub fn category_totals_by_kind(
+    conn: &Connection,
+    ym: &str,
+    kind: Kind, // Kind::Expense or Kind::Income
+) -> rusqlite::Result<Vec<CategoryTotal>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT category, SUM(amount) AS total
+        FROM entries
+        WHERE kind = ?2 AND substr(created_at, 1, 7) = ?1
+        GROUP BY category
+        ORDER BY total DESC, category ASC
+        "#,
+    )?;
+
+    let rows = stmt.query_map(params![ym, kind.to_i64()], |row| {
+        Ok(CategoryTotal {
+            category: row.get(0)?,
+            total: row.get(1)?,
+        })
+    })?;
+
+    let mut v = Vec::new();
+    for r in rows {
+        v.push(r?);
+    }
+    Ok(v)
 }


### PR DESCRIPTION
## Summary
- report category に --income / --both を追加
- 年月引数の解釈改善（-- で始まる場合は当月にフォールバック）
- 月次サマリーのSQL/構文修正

## Usage
cargo run -p cli -- report category
cargo run -p cli -- report category --income
cargo run -p cli -- report category 2025-08 --both

## Test
- 収入/支出のデータを投入して上記3コマンドで期待どおりの合計を確認
